### PR TITLE
Add support for SvelteKit built-in observability

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dist/"
   ],
   "peerDependencies": {
-    "@sveltejs/kit": "2.x"
+    "@sveltejs/kit": "^2.31.0"
   },
   "dependencies": {
     "@deno/experimental-route-config": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     }
   },
   "scripts": {
-    "fixture-deps": "cd test/fixture && npm install && npm run build",
-    "test": "npm run build && npm run fixture-deps && deno test -A",
+    "fixture-deps": "cd test/fixture && npm ci",
+    "test": "deno test -A",
     "build": "tsc && node tools/build.mjs",
     "prepublishOnly": "npm run build"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,17 @@ export default function denoAdapter(): Adapter {
       builder.log.minor("Building server entry...");
       builder.writeServer(dirs.server);
 
+      if (builder.hasServerInstrumentationFile()) {
+        builder.log.minor("Instrumenting server...");
+        builder.instrument({
+          entrypoint: `${dirs.server}/index.js`,
+          instrumentation: `${dirs.server}/instrumentation.server.js`,
+          module: {
+            exports: ["Server"],
+          },
+        });
+      }
+
       const staticFiles: DeployConfig["staticFiles"] = [];
       const redirects: DeployConfig["redirects"] = [];
       const rewrites: DeployConfig["rewrites"] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,12 @@ export default function denoAdapter(): Adapter {
       builder.log.minor("Building server entry...");
       builder.writeServer(dirs.server);
 
-      if (builder.hasServerInstrumentationFile()) {
+      // SvelteKit added these builder APIs in 2.31. Because `@sveltejs/kit` is a
+      // peer dependency, older versions may still be installed (npm warns only).
+      // Guard the call to avoid crashing on older Kit versions.
+      if (builder.hasServerInstrumentationFile?.()) {
         builder.log.minor("Instrumenting server...");
-        builder.instrument({
+        builder.instrument?.({
           entrypoint: `${dirs.server}/index.js`,
           instrumentation: `${dirs.server}/instrumentation.server.js`,
           module: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,10 @@ export default function denoAdapter(): Adapter {
         // Deno Deploy V2 always supports reading from the file system
         return true;
       },
+      instrumentation() {
+        // Does it support SvelteKit's built-in observability features
+        return true;
+      },
     },
   };
 }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -1,19 +1,48 @@
-import path from "node:path";
 import { expect } from "expect";
 import { parseHTML } from "linkedom";
+import path from "node:path";
 
 const cwd = path.join(import.meta.dirname!, "fixture");
 
-// Build package
-await new Deno.Command("npm", {
-  args: ["run", "build"],
-  cwd: Deno.cwd(),
-}).output();
-// Build fixture
-await new Deno.Command("npm", {
-  args: ["run", "build"],
-  cwd,
-}).output();
+async function removeIfExists(dir: string) {
+  try {
+    await Deno.remove(dir, { recursive: true });
+  } catch (e) {
+    if (!(e instanceof Deno.errors.NotFound)) throw e;
+  }
+}
+
+Deno.test.beforeAll(async () => {
+  await new Deno.Command("npm", {
+    args: ["run", "build"],
+    cwd: Deno.cwd(),
+  })
+    .output();
+  await new Deno.Command("npm", {
+    args: ["run", "fixture-deps"],
+    cwd: Deno.cwd(),
+  })
+    .output();
+});
+
+Deno.test.afterAll(async () => {
+  await removeIfExists(path.join(cwd, "node_modules"));
+});
+
+Deno.test.beforeEach(async () => {
+  await new Deno.Command("npm", {
+    args: ["run", "build"],
+    cwd,
+  }).output();
+});
+
+Deno.test.afterEach(async () => {
+  await Promise.all(
+    [".deno-deploy", ".svelte-kit"].map((dir) =>
+      removeIfExists(path.join(cwd, dir))
+    ),
+  );
+});
 
 async function withServer(fn: (origin: string) => Promise<void>) {
   // Intentionally confuse type checker so that it ignores this import
@@ -254,4 +283,67 @@ Deno.test("Adapter - remote functions", async () => {
       "result": '["Hello from remote function!"]',
     });
   });
+});
+
+Deno.test("Adapter - instrumentation is included when available", () => {
+  const files = Array.from(Deno.readDirSync(
+    path.join(cwd, ".deno-deploy", "server"),
+  ));
+
+  expect(files).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "instrumentation.server.js",
+        isFile: true,
+      }),
+      expect.objectContaining({
+        name: "start.js",
+        isFile: true,
+      }),
+    ]),
+  );
+
+  const instrumentationFile = Deno.readTextFileSync(path.join(
+    cwd,
+    ".deno-deploy",
+    "server",
+    "instrumentation.server.js",
+  ));
+  expect(instrumentationFile.length).toBeGreaterThan(0);
+  expect(instrumentationFile).toContain("DENO_SVELTE_ADAPTER_INSTRUMENTATION");
+});
+
+Deno.test("Adapter - instrumentation is not included when not available", async () => {
+  const instPath = path.join(cwd, "src", "instrumentation.server.ts");
+  const content = Deno.readTextFileSync(instPath);
+  try {
+    await removeIfExists(instPath);
+    await new Deno.Command("npm", {
+      args: ["run", "build"],
+      cwd,
+    }).output();
+
+    const files = Array.from(
+      Deno.readDirSync(path.join(cwd, ".deno-deploy", "server")),
+    );
+
+    ["instrumentation.server.js", "start.js"].map((name) => {
+      expect(files).not.toContainEqual(
+        expect.objectContaining({ name, isFile: true }),
+      );
+    });
+  } finally {
+    Deno.writeTextFileSync(instPath, content);
+  }
+});
+
+Deno.test("Adapter - instrumentation runs before app", () => {
+  const content = Deno.readTextFileSync(
+    path.join(cwd, ".deno-deploy", "server", "index.js"),
+  );
+  expect(content).toContain("./instrumentation.server.js");
+  expect(content).toContain("./start.js");
+  expect(content.indexOf("./instrumentation.server.js")).toBeLessThan(
+    content.indexOf("./start.js"),
+  );
 });

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -13,35 +13,23 @@ async function removeIfExists(dir: string) {
 }
 
 Deno.test.beforeAll(async () => {
+  // build package
   await new Deno.Command("npm", {
     args: ["run", "build"],
     cwd: Deno.cwd(),
   })
     .output();
+  // install fixture deps
   await new Deno.Command("npm", {
     args: ["run", "fixture-deps"],
     cwd: Deno.cwd(),
   })
     .output();
-});
-
-Deno.test.afterAll(async () => {
-  await removeIfExists(path.join(cwd, "node_modules"));
-});
-
-Deno.test.beforeEach(async () => {
+  // build fixture
   await new Deno.Command("npm", {
     args: ["run", "build"],
     cwd,
   }).output();
-});
-
-Deno.test.afterEach(async () => {
-  await Promise.all(
-    [".deno-deploy", ".svelte-kit"].map((dir) =>
-      removeIfExists(path.join(cwd, dir))
-    ),
-  );
 });
 
 async function withServer(fn: (origin: string) => Promise<void>) {
@@ -334,6 +322,10 @@ Deno.test("Adapter - instrumentation is not included when not available", async 
     });
   } finally {
     Deno.writeTextFileSync(instPath, content);
+    await new Deno.Command("npm", {
+      args: ["run", "build"],
+      cwd,
+    }).output();
   }
 });
 

--- a/test/fixture/src/instrumentation.server.ts
+++ b/test/fixture/src/instrumentation.server.ts
@@ -1,0 +1,2 @@
+(globalThis as Record<string, unknown>).__testMarker =
+  "DENO_SVELTE_ADAPTER_INSTRUMENTATION";

--- a/test/fixture/svelte.config.js
+++ b/test/fixture/svelte.config.js
@@ -14,6 +14,7 @@ const config = {
     adapter: adapter(),
     experimental: {
       remoteFunctions: true,
+      instrumentation: { server: true },
     },
   },
   compilerOptions: {


### PR DESCRIPTION
In version 2.31, the core team introduced [built-in Observability](https://svelte.dev/docs/kit/observability) to SvelteKit.  Most of the adapters they maintain already support this feature. 

In this PR, I bring the same functionality to the Deno adapter.  The changes follow the same pattern found in the official adapters, and at its core it basically moves the contents of `index.js` to a `start.js` and creates a new `index.js` that wraps both the instrumentation and the start code (and re-exports the properties from `start.js`, as not to break `handler.ts`).

Other notable changes:
- In testing, the state (more specifically `.svelte-kit` and `.deno-deploy`) was initially being set for all tests and all tests shared this state. This started to cause me issues when trying to test different states of the instrumentation flow, so I moved these to being set before each test, with the exception of `npm ci` (`ci` is being used instead of `install` as not to generate unwanted lockfile changes), that is run before all the tests.

Cheers 🤙 