### PR TITLE
CSRF protection for remote function requests

### DIFF
--- a/src/files/handler.ts
+++ b/src/files/handler.ts
@@ -70,7 +70,7 @@ export function prepareServer(
     }
 
     return new Request(
-      new URL(`${url.pathname}${url.search}${url.hash}`, origin),
+      new URL(`${url.pathname}${url.search}`, origin),
       request,
     );
   };

--- a/src/files/handler.ts
+++ b/src/files/handler.ts
@@ -47,6 +47,7 @@ export function prepareServer(
 
   const deployConfig = parseConfig(rawDeployConfig, cwd);
   const server = new Server(manifest);
+  const origin = parseOrigin(Deno.env.get("ORIGIN"));
 
   const initialized = server.init({
     env: Deno.env.toObject(),
@@ -62,6 +63,17 @@ export function prepareServer(
   const initCache = hasIsr
     ? caches.open("svelte-isr") // TODO: Are caches global?
     : Promise.resolve(null);
+
+  const normalizeRequest = (url: URL, request: Request): Request => {
+    if (origin === undefined || origin === url.origin) {
+      return request;
+    }
+
+    return new Request(
+      new URL(`${url.pathname}${url.search}${url.hash}`, origin),
+      request,
+    );
+  };
 
   const handler: Deno.ServeHandler = async (req, info) => {
     await initialized;
@@ -86,7 +98,7 @@ export function prepareServer(
       return responded;
     }
 
-    const res = await server.respond(req, {
+    const res = await server.respond(normalizeRequest(url, req), {
       getClientAddress() {
         if ("hostname" in info.remoteAddr) {
           return info.remoteAddr.hostname;
@@ -158,4 +170,29 @@ function toCacheKey(url: URL, config: IsrConfig): Request {
   }
 
   return new Request(newUrl);
+}
+
+function parseOrigin(origin?: string): string | undefined {
+  if (origin === undefined || origin === "") {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(origin.trim());
+
+    if (!["http:", "https:"].includes(url.protocol)) {
+      throw new Error(
+        `Invalid ORIGIN: ${origin}. Only http and https are supported. Received protocol: ${url.protocol}`,
+      );
+    }
+    return url.origin;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error(
+        `Invalid ORIGIN: ${origin}. ORIGIN must be a valid URL with http:// or https:// protocol.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -1,6 +1,6 @@
-import path from "node:path";
 import { expect } from "expect";
 import { parseHTML } from "linkedom";
+import path from "node:path";
 
 const cwd = path.join(import.meta.dirname!, "fixture");
 
@@ -15,7 +15,10 @@ await new Deno.Command("npm", {
   cwd,
 }).output();
 
-async function withServer(fn: (origin: string) => Promise<void>) {
+async function withServer(
+  fn: (origin: string) => Promise<void>,
+  env?: Record<string, string>,
+) {
   // Intentionally confuse type checker so that it ignores this import
   const file = "handler.ts";
   const specifier = `./fixture/.deno-deploy/${file}`;
@@ -26,29 +29,52 @@ async function withServer(fn: (origin: string) => Promise<void>) {
   const deployConfig = await import("./fixture/.deno-deploy/deploy.json", {
     with: { type: "json" },
   });
-  const handler = mod.prepareServer(
-    svelteData.default,
-    deployConfig.default,
-    cwd,
-  );
 
-  // const server = new FakeServer(handler);
-  const inst = await new Promise<
-    { server: () => Deno.HttpServer<Deno.NetAddr>; addr: Deno.NetAddr }
-  >((resolve) => {
-    const server = Deno.serve({
-      port: 0,
-      onListen: (addr) => {
-        resolve({ server: () => server, addr });
-      },
-    }, handler);
-  });
+  const previousEnv: Record<string, string | undefined> = {};
+  if (env) {
+    for (const key of Object.keys(env)) {
+      previousEnv[key] = Deno.env.get(key);
+    }
+    for (const [key, value] of Object.entries(env)) {
+      Deno.env.set(key, value);
+    }
+  }
 
-  const origin = `http://${inst.addr.hostname}:${inst.addr.port}`;
   try {
-    await fn(origin);
+    const handler = mod.prepareServer(
+      svelteData.default,
+      deployConfig.default,
+      cwd,
+    );
+
+    // const server = new FakeServer(handler);
+    const inst = await new Promise<
+      { server: () => Deno.HttpServer<Deno.NetAddr>; addr: Deno.NetAddr }
+    >((resolve) => {
+      const server = Deno.serve({
+        port: 0,
+        onListen: (addr) => {
+          resolve({ server: () => server, addr });
+        },
+      }, handler);
+    });
+
+    const origin = `http://${inst.addr.hostname}:${inst.addr.port}`;
+    try {
+      await fn(origin);
+    } finally {
+      await inst.server().shutdown();
+    }
   } finally {
-    await inst.server().shutdown();
+    if (env) {
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (value === undefined) {
+          Deno.env.delete(key);
+        } else {
+          Deno.env.set(key, value);
+        }
+      }
+    }
   }
 }
 
@@ -225,6 +251,30 @@ Deno.test("Adapter - ISR only specific search params", async () => {
       expect(newTime).not.toEqual(renderTime);
     }
   });
+});
+
+Deno.test("Adapter - Successfully protects against CSRF when ORIGIN is set", async () => {
+  const trustedOrigin = "https://foo.bar";
+  await withServer(async (serverOrigin) => {
+    const res = await fetch(`${serverOrigin}/origin-check`);
+    expect(res.status).toEqual(200);
+    const document = toDom(await res.text());
+    const seenOrigin = document.querySelector("[data-origin]")?.textContent
+      ?.trim();
+    expect(serverOrigin).not.toEqual(trustedOrigin);
+    expect(seenOrigin).toEqual(trustedOrigin);
+  }, {
+    ORIGIN: trustedOrigin,
+  });
+});
+
+Deno.test("Adapter - Fails to set up the server when ORIGIN is invalid", async () => {
+  await expect(
+    withServer(
+      () => Promise.resolve(),
+      { ORIGIN: "ftp://foo.bar" },
+    ),
+  ).rejects.toThrow();
 });
 
 Deno.test("Adapter - remote functions", async () => {

--- a/test/fixture/src/routes/origin-check/+page.server.ts
+++ b/test/fixture/src/routes/origin-check/+page.server.ts
@@ -1,0 +1,5 @@
+import type { PageServerLoad } from "./$types";
+
+export const load = (({ url }) => {
+  return { origin: url.origin };
+}) satisfies PageServerLoad;

--- a/test/fixture/src/routes/origin-check/+page.svelte
+++ b/test/fixture/src/routes/origin-check/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { PageData } from "./$types";
+  let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+  <title>Origin check</title>
+</svelte:head>
+
+<div class="text-column">
+  <h1>Origin check</h1>
+  <p data-origin>{data.origin}</p>
+</div>

--- a/test/fixture/src/routes/origin-check/+page.ts
+++ b/test/fixture/src/routes/origin-check/+page.ts
@@ -1,0 +1,4 @@
+import { dev } from "$app/environment";
+
+export const csr = dev;
+export const prerender = false;


### PR DESCRIPTION
**TL;DR** In this PR we add support for an ORIGIN environment variable.

Sometimes, due to reverse proxying and host limitations, the origin of browser-made remote function requests doesn’t match the URL the SvelteKit app is running on, and form remote function calls fail with `403 Cross-site POST form submissions are forbidden.`.

The SvelteKit maintainers agreed that the right fix is for the adapter to normalize the request so the app sees the correct origin (e.g. via an ORIGIN-style env var), rather than relaxing CSRF (e.g. with trustedOrigins). That way the origin is derived from the request URL the adapter passes to the server, and CSRF checks (including for remote functions) work without weakening security. See the discussion can be found [here](https://github.com/sveltejs/kit/pull/14795), in particular [Rich’s comment](https://github.com/sveltejs/kit/pull/14795#issuecomment-3590007596) on `request.url` and the `adapter-node` ORIGIN pattern.

By having access to ORIGIN, the handler rewrites incoming request URLs to that origin (keeping pathname, search, and hash) before passing the request to SvelteKit, so `request.url` (and thus CSRF and remote function checks) use the correct public origin.