### PR TITLE
Feat/assets from manifest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,17 +103,18 @@ export default function denoAdapter(): Adapter {
         destination: ".deno-deploy/static/_app/immutable/:file*",
       });
 
-      // Collect all remaining asset files
-      const assetDir = builder.config.kit.files.assets;
+      // Add assets from manifest
+      const manifestPath = path.join(
+        builder.getServerDirectory(),
+        "manifest.js",
+      );
+      const manifest = (await import(manifestPath)).manifest;
+      const assets = manifest.assets;
 
-      // TODO: What about generated assets
-      const assets: string[] = [];
-      await walk(assetDir, assets);
       for (const asset of assets) {
-        const rel = path.relative(assetDir, asset);
         staticFiles.push({
-          source: `/${rel.replace(/\\+/, "/")}`,
-          destination: path.join(dirs.static, rel),
+          source: `/${asset.replace(/\\+/, "/")}`,
+          destination: path.join(dirs.static, asset),
         });
       }
 
@@ -151,14 +152,4 @@ export default function denoAdapter(): Adapter {
       },
     },
   };
-}
-
-async function walk(dir: string, result: string[]): Promise<void> {
-  for (const entry of await fsp.readdir(dir, { withFileTypes: true })) {
-    if (entry.isDirectory()) {
-      await walk(path.join(dir, entry.name), result);
-    } else if (entry.isFile()) {
-      result.push(path.join(dir, entry.name));
-    }
-  }
 }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -123,6 +123,18 @@ Deno.test("Adapter - serve static file: robots.txt (content)", async () => {
   });
 });
 
+Deno.test("Adapter - serve static file: service-worker.js (generated)", async () => {
+  await withServer(async (origin) => {
+    const res = await fetch(`${origin}/service-worker.js`);
+
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("Content-Type")).toEqual(
+      "text/javascript; charset=utf-8",
+    );
+    expect(await res.text()).toContain("Placeholder service worker");
+  });
+});
+
 Deno.test("Adapter - serve static files with cache headers", async () => {
   const immutableDir = path.join(
     cwd,

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -57,6 +57,22 @@ function toDom(input: string): Document {
   return (parseHTML(input) as any).document as Document;
 }
 
+async function collectStaticFiles(
+  dir: string,
+  base: string = dir,
+): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    const fullPath = `${dir}/${entry.name}`;
+    if (entry.isDirectory) {
+      files.push(...await collectStaticFiles(fullPath, base));
+    } else {
+      files.push(fullPath.slice(base.length + 1));
+    }
+  }
+  return files;
+}
+
 Deno.test("Adapter - starts", async () => {
   await withServer(async (origin) => {
     const res = await fetch(`${origin}/`);
@@ -81,7 +97,21 @@ Deno.test("Adapter - redirects /about/ -> /about", async () => {
   });
 });
 
-Deno.test("Adapter - serve static files from root", async () => {
+const staticFiles = await collectStaticFiles(
+  new URL("fixture/static", import.meta.url).pathname,
+);
+
+for (const file of staticFiles) {
+  Deno.test(`Adapter - serve static file: ${file}`, async () => {
+    await withServer(async (origin) => {
+      const res = await fetch(`${origin}/${file}`);
+      expect(res.status).toEqual(200);
+      await res.body?.cancel();
+    });
+  });
+}
+
+Deno.test("Adapter - serve static file: robots.txt (content)", async () => {
   await withServer(async (origin) => {
     const res = await fetch(`${origin}/robots.txt`);
 

--- a/test/fixture/src/service-worker.ts
+++ b/test/fixture/src/service-worker.ts
@@ -1,0 +1,3 @@
+const placeholder = "Placeholder service worker";
+
+console.log(placeholder);


### PR DESCRIPTION
This PR changes how the list of static files is generated. Instead of reading the contents of the `assets` directory it reads the list directly from the the manifest file generated by svelte kit.

Main reason for this change is that creating the assets list from the contents of the `assets` directory misses out on files generated during the build as mentioned in https://github.com/denoland/svelte-adapter/issues/16. 

This is done by importing the `manifest.js` file via its path as the `builder` object doesn't expose the manifest itself (or the assets list).

I updated the tests to:

- dynamically create one test per file in `assets`, checking that all files are served
- added an extra file in a subdirectory (which is then tested as mentioned above)
- added a `service-worker.ts` file to the fixture project, and added a test to check that it is served

Marked this PR as draft since I don't think it covers all the cases (e.g. workbox, service worker webmanifest generation), which I'll look into later. 

Closes https://github.com/denoland/svelte-adapter/issues/16